### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/blog-be.yml
+++ b/.github/workflows/blog-be.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build image and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kamko/lnu_ht19_4me310_final_project_blog-be
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/blog-db.yml
+++ b/.github/workflows/blog-db.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build image and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kamko/lnu_ht19_4me310_final_project_blog-db
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/blog-fe.yml
+++ b/.github/workflows/blog-fe.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build image and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kamko/lnu_ht19_4me310_final_project_blog-fe
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/predictor.yml
+++ b/.github/workflows/predictor.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build image and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kamko/lnu_ht19_4me310_final_project_blog-predictor
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore